### PR TITLE
Replace formatted output with data objects

### DIFF
--- a/PureStoragePowerShellToolkit.WindowsAdministration/PureStoragePowerShellToolkit.WindowsAdministration.psm1
+++ b/PureStoragePowerShellToolkit.WindowsAdministration/PureStoragePowerShellToolkit.WindowsAdministration.psm1
@@ -1498,7 +1498,7 @@ function Test-Item() {
         }
     }
     else {
-        Write-TestLog "$header has not recommended value" -Severity Failed @p
+        Write-TestLog "$header does not have recommended value" -Severity Failed @p
     }
 }
 


### PR DESCRIPTION
Some cmdlets produce formatted output which cannot be consumed by any commands or scripts. This pull request makes those functions produce plain data objects instead of text.

**NOTE** Some formatting has been dropped.
**NOTE** rounding to GB has been dropped until a decision is made on the final solution.

Related issue #61 .