### PR TITLE
Downgrade dbatools

### DIFF
--- a/Import-PureStoragePowerShellToolkit.Core.ps1
+++ b/Import-PureStoragePowerShellToolkit.Core.ps1
@@ -47,5 +47,5 @@ function Import-ModuleManually {
     }
 }
 
-'PureStoragePowershellToolkit.FlashArray',
-'PureStoragePowershellToolkit.DatabaseTools' | Import-ModuleManually
+'PureStoragePowerShellToolkit.FlashArray',
+'PureStoragePowerShellToolkit.DatabaseTools' | Import-ModuleManually

--- a/Import-PureStoragePowerShellToolkit.ps1
+++ b/Import-PureStoragePowerShellToolkit.ps1
@@ -1,5 +1,5 @@
 . $PSScriptRoot\Import-PureStoragePowerShellToolkit.Core.ps1
 
-'PureStoragePowershellToolkit.WindowsAdministration',
-'PureStoragePowershellToolkit.Reporting',
-'PureStoragePowershellToolkit.Exchange' | Import-ModuleManually
+'PureStoragePowerShellToolkit.WindowsAdministration',
+'PureStoragePowerShellToolkit.Reporting',
+'PureStoragePowerShellToolkit.Exchange' | Import-ModuleManually

--- a/PureStoragePowerShellToolkit.DatabaseTools/PureStoragePowerShellToolkit.DatabaseTools.psd1
+++ b/PureStoragePowerShellToolkit.DatabaseTools/PureStoragePowerShellToolkit.DatabaseTools.psd1
@@ -75,7 +75,7 @@ RequiredModules = @(
     },
     @{
         ModuleName = 'dbatools'
-        ModuleVersion = '1.1.146'
+        ModuleVersion = '1.0.173'
     }
 )
 

--- a/PureStoragePowerShellToolkit.DatabaseTools/PureStoragePowerShellToolkit.DatabaseTools.psm1
+++ b/PureStoragePowerShellToolkit.DatabaseTools/PureStoragePowerShellToolkit.DatabaseTools.psm1
@@ -21,7 +21,7 @@
 
 #Requires -Version 5
 #Requires -Modules @{ ModuleName='PureStoragePowerShellToolkit.FlashArray'; ModuleVersion='3.0.0.3' }
-#Requires -Modules @{ ModuleName='dbatools'; ModuleVersion='1.1.146' }
+#Requires -Modules @{ ModuleName='dbatools'; ModuleVersion='1.0.173' }
 
 #region Helper functions
 


### PR DESCRIPTION
dbatools 1.1.0-1.1.146 has an issue with loading Micrsofot.SqlServer.XE.Core.dll.

- Downgrade dbatools to 1.0.173
- Minor filename fix affecting case sensitive filesystems.

Closes #74 